### PR TITLE
Implemented custom fmt in java date format

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ $ go install github.com/s-ichikawa/ts2d@latest
 ```
 $ echo 1660358443.2188597 | ts2d
 "2022-08-13 11:40:43.002188597 +0900 JST"
+
+$ echo 1660358443.2188597 | ts2d -f "2006-01-02T15:04:05-07:00"
+"2022-08-13T11:40:43+09:00"
+
+$ echo 1660358443.2188597 | ./ts2d -jf "yyyy/MM/dd 'at' hh:mm:ss a z"
+"2022/08/13 at 11:40:43 AM JST"
 ```
 
 example of kubectl logs

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ $ go install github.com/s-ichikawa/ts2d@latest
 $ echo 1660358443.2188597 | ts2d
 "2022-08-13 11:40:43.002188597 +0900 JST"
 
-$ echo 1660358443.2188597 | ts2d -f "2006-01-02T15:04:05-07:00"
+$ echo 1660358443.2188597 | ts2d -gf "2006-01-02T15:04:05-07:00"
 "2022-08-13T11:40:43+09:00"
 
-$ echo 1660358443.2188597 | ./ts2d -jf "yyyy/MM/dd 'at' hh:mm:ss a z"
+$ echo 1660358443.2188597 | ./ts2d -f "yyyy/MM/dd 'at' hh:mm:ss a z"
 "2022/08/13 at 11:40:43 AM JST"
 ```
 

--- a/internal/date_format/convertor.go
+++ b/internal/date_format/convertor.go
@@ -1,0 +1,5 @@
+package date_format
+
+type convertor interface {
+	ToLayout() string
+}

--- a/internal/date_format/java_simple_date.go
+++ b/internal/date_format/java_simple_date.go
@@ -1,0 +1,98 @@
+package date_format
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const (
+	singleQuotedEscape = "${SQ}"
+	tokenTmpl          = "${T%d}"
+)
+
+type javaSimpleDateConvertor struct {
+	format string
+}
+
+func NewJavaSimpleDateConvertor(format string) javaSimpleDateConvertor {
+	return javaSimpleDateConvertor{
+		format: format,
+	}
+}
+
+func (c javaSimpleDateConvertor) ToLayout() string {
+	return c.parseFmt(c.format)
+}
+
+func (c javaSimpleDateConvertor) parseFmt(fmt string) string {
+	// create tokens
+	l, tokens := c.generateTokens(fmt)
+
+	// hour
+	l = strings.Replace(l, "HH", "15", -1)
+	l = strings.Replace(l, "H", "15", -1)
+	l = strings.Replace(l, "hh", "03", -1)
+	l = strings.Replace(l, "h", "3", -1)
+	l = strings.Replace(l, "a", "PM", -1)
+	// minute
+	l = strings.Replace(l, "mm", "04", -1)
+	// second
+	l = strings.Replace(l, "ss", "05", -1)
+	// millisecond
+	l = strings.Replace(l, "SSS", "000", -1)
+
+	// year
+	l = strings.Replace(l, "yyyy", "2006", -1)
+	l = strings.Replace(l, "yy", "06", -1)
+	// month
+	l = strings.Replace(l, "MMM", "Jan", -1)
+	l = strings.Replace(l, "MM", "01", -1)
+	// day
+	l = strings.Replace(l, "dd", "02", -1)
+	l = strings.Replace(l, "d", "_2", -1)
+
+	// weekday
+	l = strings.Replace(l, "EEEE", "Monday", -1)
+	l = strings.Replace(l, "EEE", "Mon", -1)
+
+	// timezone
+	l = strings.Replace(l, "XXX", "-07:00", -1)
+	l = strings.Replace(l, "Z", "-0700", -1)
+	l = strings.Replace(l, "z", "MST", -1)
+
+	// recover tokens
+	l = c.recoverTokens(l, tokens)
+
+	return l
+}
+
+func (c javaSimpleDateConvertor) generateTokens(f string) (string, []string) {
+	// create temporary tokens for single-quoted escape char
+	f = strings.ReplaceAll(f, "''", singleQuotedEscape)
+
+	// create temporary tokens for single-quoted phrases
+	r, _ := regexp.Compile("('.*?')")
+	ts := r.FindAllString(f, -1)
+	tokens := make([]string, len(ts))
+	for i, t := range ts {
+		f = strings.Replace(f, t, fmt.Sprintf(tokenTmpl, i), -1)
+		// remove leading & trailing single quote from each token
+		tokens[i] = t[1 : len(t)-1]
+	}
+
+	return f, tokens
+}
+
+func (c javaSimpleDateConvertor) recoverTokens(f string, tokens []string) string {
+	if len(tokens) == 0 {
+		return f
+	}
+	for i, t := range tokens {
+		f = strings.Replace(f, fmt.Sprintf(tokenTmpl, i), t, -1)
+	}
+
+	// recover escaped chars
+	f = strings.ReplaceAll(f, singleQuotedEscape, "'")
+	return f
+}

--- a/internal/date_format/java_simple_date_test.go
+++ b/internal/date_format/java_simple_date_test.go
@@ -1,0 +1,65 @@
+package date_format_test
+
+import (
+	"reflect"
+	"testing"
+
+	df "github.com/s-ichikawa/ts2d/internal/date_format"
+)
+
+func TestJavaSimpleDateFormatterLayout(t *testing.T) {
+	tests := []struct {
+		name, ptn, expected string
+	}{
+		{
+			name:     "simple format",
+			ptn:      "yyyyMMdd HH:mm:ss",
+			expected: "20060102 15:04:05",
+		},
+		{
+			name:     "simple format with AM/PM & milliseconds",
+			ptn:      "yyyyMMdd h:mm:ss.SSS a",
+			expected: "20060102 3:04:05.000 PM",
+		},
+		{
+			name:     "RFC3339",
+			ptn:      "yyyy-MM-dd'T'HH:mm:ssXXX",
+			expected: "2006-01-02T15:04:05-07:00",
+		},
+		{
+			name:     "UnixDate",
+			ptn:      "EEE MMM d HH:mm:ss z yyyy",
+			expected: "Mon Jan _2 15:04:05 MST 2006",
+		},
+		{
+			name:     "RFC822",
+			ptn:      "dd MMM yy HH:mm z",
+			expected: "02 Jan 06 15:04 MST",
+		},
+		{
+			name:     "RFC850",
+			ptn:      "EEEE, dd-MMM-yy HH:mm:ss z",
+			expected: "Monday, 02-Jan-06 15:04:05 MST",
+		},
+		{
+			name:     "RFC1123",
+			ptn:      "EEE, dd MMM yyyy HH:mm:ss z",
+			expected: "Mon, 02 Jan 2006 15:04:05 MST",
+		},
+		{
+			name:     "With single-quoted words",
+			ptn:      "'at' hh 'o''clock' a, z",
+			expected: "at 03 o'clock PM, MST",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			f := df.NewJavaSimpleDateConvertor(tt.ptn)
+			got := f.ToLayout()
+			if !reflect.DeepEqual(tt.expected, got) {
+				t.Fatalf("expected: %v, got: %v", tt.expected, got)
+			}
+		})
+	}
+}

--- a/internal/ts2d.go
+++ b/internal/ts2d.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	df "github.com/s-ichikawa/ts2d/internal/date_format"
 )
 
 const (
@@ -23,6 +25,11 @@ var (
 
 func SetCustomFormat(f string) {
 	customFormat = f
+}
+
+func SetCustomFormatInJavaDataPattern(f string) {
+	r := df.NewJavaSimpleDateConvertor(f)
+	customFormat = r.ToLayout()
 }
 
 func TimestampToDate(in string) string {

--- a/internal/ts2d.go
+++ b/internal/ts2d.go
@@ -23,7 +23,7 @@ var (
 	customFormat = ""
 )
 
-func SetCustomFormat(f string) {
+func SetCustomFormatInGoLayout(f string) {
 	customFormat = f
 }
 

--- a/ts2d.go
+++ b/ts2d.go
@@ -10,21 +10,21 @@ import (
 	"github.com/s-ichikawa/ts2d/internal"
 )
 
-var customFormat, customJavaDateFormat string
+var customFormat, customGoDateFormat string
 
 func main() {
 	flag.StringVar(&customFormat, "format", "", "")
 	flag.StringVar(&customFormat, "f", "", "")
-	flag.StringVar(&customJavaDateFormat, "java-format", "", "")
-	flag.StringVar(&customJavaDateFormat, "jf", "", "")
+	flag.StringVar(&customGoDateFormat, "go-format", "", "")
+	flag.StringVar(&customGoDateFormat, "gf", "", "")
 
 	flag.Parse()
 
-	// `customFormat`, i.e. golang layout is top-class citizen.
+	// `customFormat`, i.e. Java date template is the top-class citizen.
 	if customFormat != "" {
-		internal.SetCustomFormat(customFormat)
-	} else if customJavaDateFormat != "" {
-		internal.SetCustomFormatInJavaDataPattern(customJavaDateFormat)
+		internal.SetCustomFormatInJavaDataPattern(customFormat)
+	} else if customGoDateFormat != "" {
+		internal.SetCustomFormatInGoLayout(customGoDateFormat)
 	}
 
 	r := bufio.NewReader(os.Stdin)

--- a/ts2d.go
+++ b/ts2d.go
@@ -10,16 +10,21 @@ import (
 	"github.com/s-ichikawa/ts2d/internal"
 )
 
-var customFormat string
+var customFormat, customJavaDateFormat string
 
 func main() {
 	flag.StringVar(&customFormat, "format", "", "")
 	flag.StringVar(&customFormat, "f", "", "")
+	flag.StringVar(&customJavaDateFormat, "java-format", "", "")
+	flag.StringVar(&customJavaDateFormat, "jf", "", "")
 
 	flag.Parse()
 
+	// `customFormat`, i.e. golang layout is top-class citizen.
 	if customFormat != "" {
 		internal.SetCustomFormat(customFormat)
+	} else if customJavaDateFormat != "" {
+		internal.SetCustomFormatInJavaDataPattern(customJavaDateFormat)
 	}
 
 	r := bufio.NewReader(os.Stdin)


### PR DESCRIPTION
I added custom date format support in Java `SimpleDateFormat`.

Example:
```
❯ echo 1660358443.2188597 | ./ts2d  
"2022-08-13 10:40:43.002188597 +0800 HKT"

❯ echo 1660358443.2188597 | ./ts2d -f "2006-01-02T15:04:05-07:00"
"2022-08-13T10:40:43+08:00"

❯ echo 1660358443.2188597 | ./ts2d -jf "yyyy/MM/dd 'at' hh:mm:ss a z"
"2022/08/13 at 10:40:43 AM HKT"
```

Ref:
[Java SimpleDateFormat](https://docs.oracle.com/javase/jp/8/docs/api/java/text/SimpleDateFormat.html)
[Go Layout](https://yourbasic.org/golang/format-parse-string-time-date-example/)
